### PR TITLE
test: cover uniqueById helper

### DIFF
--- a/codex-cli/tests/unique-by-id.test.ts
+++ b/codex-cli/tests/unique-by-id.test.ts
@@ -1,0 +1,47 @@
+import { describe, test, expect } from "vitest";
+import { uniqueById } from "../src/utils/model-utils";
+
+function assistant(id: string) {
+  return {
+    id,
+    type: "message",
+    role: "assistant",
+    content: [],
+  } as any;
+}
+
+function user(text: string) {
+  return {
+    type: "message",
+    role: "user",
+    content: [{ type: "input_text", text }],
+  } as any;
+}
+
+describe("uniqueById", () => {
+  test("de-duplicates items with the same id", () => {
+    const a1 = assistant("a");
+    const b = assistant("b");
+    const a2 = assistant("a");
+
+    const result = uniqueById([a1, b, a2]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(a1);
+    expect(result[1]).toBe(b);
+  });
+
+  test("collapses consecutive identical user messages", () => {
+    const u1 = user("hi");
+    const u2 = user("hi");
+    const asst = assistant("x");
+    const u3 = user("hi");
+
+    const result = uniqueById([u1, u2, asst, u3]);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toBe(u1);
+    expect(result[1]).toBe(asst);
+    expect(result[2]).toBe(u3);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for uniqueById covering id-based dedupe and collapse of repeated user messages

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_685076bebf2483208687ce6f05ba6e9a